### PR TITLE
Added customizable timeout parameter to download_dir to be used by download_xnat_dir

### DIFF
--- a/R/xnat_api.R
+++ b/R/xnat_api.R
@@ -562,7 +562,8 @@ xnat_connect <- function(base_url, username=NULL, password=NULL, xnat_name=NULL,
                            zipped = TRUE,
                            verbose = FALSE,
                            error = FALSE, 
-                           extract = FALSE){
+                           extract = FALSE,
+                           timeout_duration = 200){
     if(is.null(file_dir)) {
       file_dir <- tempdir()
     }
@@ -583,7 +584,7 @@ xnat_connect <- function(base_url, username=NULL, password=NULL, xnat_name=NULL,
         write_disk(path = destfile,
                    overwrite = TRUE),
         set_cookies(JSESSIONID = jsid),
-        timeout(200)
+        timeout(timeout_duration)
       )
       if (verbose) {
         args = c(args, list(progress()))


### PR DESCRIPTION
Introduced a new optional `timeout_duration` parameter to the `download_dir` function, called by `download_xnat_dir`, to accommodate larger files or slower network speeds. 

Changes:

- Added `timeout_duration` parameter to `download_dir` with a default value of 200 seconds.
- Replaced the hardcoded timeout value of 200 with the `timeout_duration` value.

Rationale:

I received a timeout error when trying to use download_xnat_dir to download a 2 GB zipped experiment file from my local xnat instance. Introducing a timeout_duration parameter provides more user flexibility for large file sizes. 

Testing:


> download_xnat_dir(my_xnat, my_experiment, timeout_duration = 5)
Error in curl::curl_fetch_disk(url, x$path, handle = handle) :
  Timeout was reached: [my.xnat] Operation timed out after 5001 milliseconds with 0 out of -1 bytes received

> download_xnat_dir(my_xnat, my_experiment)
Error in curl::curl_fetch_disk(url, x$path, handle = handle) :
  Timeout was reached: [my.xnat] Operation timed out after 200000 milliseconds with 659885554 out of -1 bytes received

> download_xnat_dir(my_xnat, my_experiment, timeout_duration = 480)
[success]

> download_xnat_dir(my_xnat, my_experiment, timeout_duration = 0)
Error: Timeout cannot be less than 1 ms
